### PR TITLE
[RFR] Updated markup generated by drawEmojiStats

### DIFF
--- a/views/application.coffee
+++ b/views/application.coffee
@@ -137,12 +137,12 @@ drawEmojiStats = (stats, callback) ->
     do (emoji_char) ->
       @score_cache[emoji_char.id] = emoji_char.score
       selector.append "
-        <a href='/details/#{emoji_char.id}' title='#{emoji_char.name}' data-id='#{emoji_char.id}'>
         <li class='emoji_char' id='#{emoji_char.id}' data-title='#{emoji_char.name}'>
-          <span class='char emojifont'>#{emoji.replace_unified(emoji_char.char)}</span>
-          <span class='score' id='score-#{emoji_char.id}'>#{emoji_char.score}</span>
-        </li>
-        </a>"
+          <a href='/details/#{emoji_char.id}' title='#{emoji_char.name}' data-id='#{emoji_char.id}'>
+            <span class='char emojifont'>#{emoji.replace_unified(emoji_char.char)}</span>
+            <span class='score' id='score-#{emoji_char.id}'>#{emoji_char.score}</span>
+          </a>
+        </li>"
   callback() if (callback)
 
 # getter for cached score_selector elements


### PR DESCRIPTION
`<li>` is the only child authorised in a `<ul>` element to have valid markup. Right now, the `drawEmojiStats` function wraps each `<li>` in a `<a>` tag. I recommend do it the other way around: have a `<a>` element directly inside each `<li>`.

This PR simply does that.
