### PR TITLE
Use HTTPS for Favicon

### DIFF
--- a/views/layout.slim
+++ b/views/layout.slim
@@ -3,7 +3,7 @@ html data-stream-server="#{STREAM_SERVER}" data-api-uri="#{web_api_uri}"
   head
     meta charset="utf-8"
     title emojitracker: realtime emoji use on twitter
-    link rel="icon" type="image/png" href="http://emojistatic.github.io/images/32/1f4ab.png"
+    link rel="icon" type="image/png" href="https://emojistatic.github.io/images/32/1f4ab.png"
     meta name="viewport" content="width=device-width, initial-scale=1.0"
     meta name="apple-mobile-web-app-capable" content="yes"
 


### PR DESCRIPTION
Otherwise it's blocked when the page is loaded over HTTPS

![image](https://user-images.githubusercontent.com/4192774/109542054-2a60e200-7a8a-11eb-8202-d77d4fdb8c29.png)
